### PR TITLE
fix MIC calculation

### DIFF
--- a/lib/as2/message.rb
+++ b/lib/as2/message.rb
@@ -2,25 +2,28 @@ require 'as2/base64_helper'
 
 module As2
   class Message
-    attr_reader :original_message
+    attr_reader :pkcs7
 
     def initialize(message, private_key, public_certificate)
-      @original_message = message
+      # TODO: might need to use OpenSSL::PKCS7.read_smime rather than .new sometimes
+      @pkcs7 = OpenSSL::PKCS7.new(message)
       @private_key = private_key
       @public_certificate = public_certificate
     end
 
     def decrypted_message
-      @decrypted_message ||= decrypt_smime(original_message)
+      @decrypted_message ||= @pkcs7.decrypt @private_key, @public_certificate
     end
 
     def valid_signature?(partner_certificate)
       store = OpenSSL::X509::Store.new
       store.add_cert(partner_certificate)
 
-      smime = Base64Helper.ensure_body_base64(decrypted_message)
-      message = read_smime(smime)
-      message.verify [partner_certificate], store
+      @pkcs7.verify [partner_certificate], store
+    end
+
+    def mic
+      OpenSSL::Digest::SHA1.base64digest(attachment.raw_source.strip)
     end
 
     # Return the attached file, use .filename and .body on the return value
@@ -33,17 +36,9 @@ module As2
     end
 
     private
+
     def mail
       @mail ||= Mail.new(decrypted_message)
-    end
-
-    def read_smime(smime)
-      OpenSSL::PKCS7.read_smime(smime)
-    end
-
-    def decrypt_smime(smime)
-      message = read_smime(smime)
-      message.decrypt @private_key, @public_certificate
     end
   end
 end


### PR DESCRIPTION
the way `smime_string` was being constructed in [`Server#build_smime_text`](https://github.com/officeluv/as2/blob/f685a776b5f93b038165510d340e7d7644919ee4/lib/as2/server.rb#L61-L74) meant the MIC was being calculated on a different string. hence it would never match what the sender is expecting.

before this change, when sending a message from mendelson AS2 to ruby AS2, i saw this message in the mendelson logs:

> The Message Integrity Code (MIC) does not match the sent AS2 message (required: AjB6m2ItoyT/URid63rbmZmCl8g=, sha1, returned: IX1Oqork7XjLfOXCfJL/W5+/b5U=, sha1).

after this change, re-running the same transmission results in

> The Message Integrity Code (MIC) matches the sent AS2 message.

In putting this together, I never figured out why `Base64Helper.ensure_base64` was needed - so I may have missed something here. I'll be happy to make adjustments.