### PR TITLE
allow code outside of Server to build MDN responses

### DIFF
--- a/lib/as2/server.rb
+++ b/lib/as2/server.rb
@@ -50,17 +50,6 @@ module As2
       send_mdn(env, message.mic)
     end
 
-    private
-
-    def logger(env)
-      @logger ||= Logger.new env['rack.errors']
-    end
-
-    def send_error(env, msg)
-      logger(env).error msg
-      send_mdn env, nil, msg
-    end
-
     def send_mdn(env, mic, failed = nil)
       report = MimeGenerator::Part.new
       report['Content-Type'] = 'multipart/report; report-type=disposition-notification'
@@ -113,6 +102,17 @@ module As2
       headers['Connection'] = 'close'
 
       [200, headers, ["\r\n" + smime_signed]]
+    end
+
+    private
+
+    def logger(env)
+      @logger ||= Logger.new env['rack.errors']
+    end
+
+    def send_error(env, msg)
+      logger(env).error msg
+      send_mdn env, nil, msg
     end
   end
 end


### PR DESCRIPTION
the `As2::Server` class lays out a good outline for how to handle an incoming message, but i need more control over some parts of the process - primarily for error handling and logging. 

i plan to eventually refactor `As2::Server` to allow this, but for now i'm just using `As2::Message` directly in my external code. The only part of `As2::Server` I actually need is the code which builds an MDN response.