### PR TITLE
client: correct MIC & signature verification when processing MDN response

### DIFF
--- a/as2.gemspec
+++ b/as2.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency "thin"
   spec.add_development_dependency "minitest"
+  spec.add_development_dependency "minitest-focus"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "pry"
 end

--- a/lib/as2.rb
+++ b/lib/as2.rb
@@ -3,6 +3,7 @@ require 'mail'
 require 'as2/config'
 require 'as2/server'
 require 'as2/client'
+require 'as2/digest_selector'
 require "as2/version"
 
 module As2

--- a/lib/as2.rb
+++ b/lib/as2.rb
@@ -3,6 +3,7 @@ require 'mail'
 require 'as2/config'
 require 'as2/server'
 require 'as2/client'
+require 'as2/client/result'
 require 'as2/digest_selector'
 require "as2/version"
 

--- a/lib/as2.rb
+++ b/lib/as2.rb
@@ -18,6 +18,6 @@ module As2
   end
 
   def self.generate_message_id(server_info)
-    "<#{server_info.name}-#{Time.now.strftime('%Y%m%d%-H%M%S')}-#{SecureRandom.uuid}@#{server_info.domain}>"
+    "<#{server_info.name}-#{Time.now.strftime('%Y%m%d-%H%M%S')}-#{SecureRandom.uuid}@#{server_info.domain}>"
   end
 end

--- a/lib/as2.rb
+++ b/lib/as2.rb
@@ -1,5 +1,6 @@
 require 'openssl'
 require 'mail'
+require 'securerandom'
 require 'as2/config'
 require 'as2/server'
 require 'as2/client'
@@ -14,5 +15,9 @@ module As2
 
   def self.reset_config!
     Config.reset!
+  end
+
+  def self.generate_message_id(server_info)
+    "<#{server_info.name}-#{Time.now.strftime('%Y%m%d%-H%M%S')}-#{SecureRandom.uuid}@#{server_info.domain}>"
   end
 end

--- a/lib/as2/client.rb
+++ b/lib/as2/client.rb
@@ -22,8 +22,6 @@ module As2
       @server_info = server_info || Config.server_info
     end
 
-    Result = Struct.new :success, :response, :mic_matched, :mid_matched, :body, :disp_code
-
     # Send a file to a partner
     #
     #   * If the content parameter is omitted, then `file_name` must be a path

--- a/lib/as2/client/result.rb
+++ b/lib/as2/client/result.rb
@@ -1,0 +1,31 @@
+module As2
+  class Client
+    class Result
+      attr_reader :response, :mic_matched, :mid_matched, :body, :disposition, :verification_error, :exception
+
+      def initialize(response, mic_matched, mid_matched, body, disposition, verification_error, exception)
+        @response = response
+        @mic_matched = mic_matched
+        @mid_matched = mid_matched
+        @body = body
+        @disposition = disposition
+        @verification_error = verification_error
+        @exception = exception
+      end
+
+      def verified?
+        self.verification_error.nil?
+      end
+
+      # legacy name. accessor for backwards-compatibility.
+      def disp_code
+        self.disposition
+      end
+
+      def success
+        # TODO: we'll never have success if MDN is unsigned.
+        self.verified? && self.mic_matched && self.mid_matched && self.disposition&.end_with?('processed')
+      end
+    end
+  end
+end

--- a/lib/as2/client/result.rb
+++ b/lib/as2/client/result.rb
@@ -24,11 +24,16 @@ module As2
       end
 
       def success
+        # 'processed' is good (though may include warnings.)
+        # 'processed/error' is not.
+        downcased_disposition = self.disposition.to_s.downcase
+
         # TODO: we'll never have success if MDN is unsigned.
         self.signature_verified &&
         self.mic_matched &&
         self.mid_matched &&
-        self.disposition&.include?('processed')
+        downcased_disposition.include?('processed') &&
+        !downcased_disposition.include?('processed/error')
       end
     end
   end

--- a/lib/as2/client/result.rb
+++ b/lib/as2/client/result.rb
@@ -1,20 +1,21 @@
 module As2
   class Client
     class Result
-      attr_reader :response, :mic_matched, :mid_matched, :body, :disposition, :verification_error, :exception
+      attr_reader :response, :mic_matched, :mid_matched, :body, :disposition, :signature_verification_error, :exception, :outbound_message_id
 
-      def initialize(response, mic_matched, mid_matched, body, disposition, verification_error, exception)
+      def initialize(response:, mic_matched:, mid_matched:, body:, disposition:, signature_verification_error:, exception:, outbound_message_id:)
         @response = response
         @mic_matched = mic_matched
         @mid_matched = mid_matched
         @body = body
         @disposition = disposition
-        @verification_error = verification_error
+        @signature_verification_error = signature_verification_error
         @exception = exception
+        @outbound_message_id = outbound_message_id
       end
 
-      def verified?
-        self.verification_error.nil?
+      def signature_verified
+        self.signature_verification_error.nil?
       end
 
       # legacy name. accessor for backwards-compatibility.
@@ -24,7 +25,10 @@ module As2
 
       def success
         # TODO: we'll never have success if MDN is unsigned.
-        self.verified? && self.mic_matched && self.mid_matched && self.disposition&.end_with?('processed')
+        self.signature_verified &&
+        self.mic_matched &&
+        self.mid_matched &&
+        self.disposition&.include?('processed')
       end
     end
   end

--- a/lib/as2/digest_selector.rb
+++ b/lib/as2/digest_selector.rb
@@ -1,0 +1,23 @@
+require 'openssl'
+
+module As2
+  class DigestSelector
+    @map = {
+      'sha1' => OpenSSL::Digest::SHA1,
+      'sha256' => OpenSSL::Digest::SHA256,
+      'sha384' => OpenSSL::Digest::SHA384,
+      'sha512' => OpenSSL::Digest::SHA512,
+      'md5' => OpenSSL::Digest::MD5
+    }
+
+    def self.valid_codes
+      @map.keys
+    end
+
+    def self.for_code(code)
+      normalized = code.strip.downcase.gsub(/[^a-z0-9]/, '')
+
+      @map[normalized] || OpenSSL::Digest::SHA1
+    end
+  end
+end

--- a/lib/as2/message.rb
+++ b/lib/as2/message.rb
@@ -80,6 +80,7 @@ module As2
     end
 
     def mic
+      # TODO: could use As2::DigestSelector if a different algo is needed.
       OpenSSL::Digest::SHA1.base64digest(attachment.raw_source.strip)
     end
 

--- a/lib/as2/server.rb
+++ b/lib/as2/server.rb
@@ -103,7 +103,7 @@ module As2
       headers = {}
       headers['Content-Type'] = content_type
       headers['MIME-Version'] = '1.0'
-      headers['Message-ID'] = "<#{@server_info.name}-#{Time.now.strftime('%Y%m%d%H%M%S')}@#{@server_info.domain}>"
+      headers['Message-ID'] = As2.generate_message_id(@server_info)
       headers['AS2-From'] = @server_info.name
       headers['AS2-To'] = env['HTTP_AS2_FROM']
       headers['AS2-Version'] = '1.2'

--- a/test/as2_test.rb
+++ b/test/as2_test.rb
@@ -1,7 +1,18 @@
 require 'test_helper'
 
-class As2Test < Minitest::Test
-  def test_that_it_has_a_version_number
-    refute_nil ::As2::VERSION
+describe As2 do
+  describe '.generate_message_id' do
+    it 'creates a message id string based on given server_info' do
+      server_info = build_server_info('BOB', credentials: 'server')
+
+      message_ids = []
+      5.times do
+        message_id = As2.generate_message_id(server_info)
+        message_ids << message_id
+        assert message_id.match(/^\<#{server_info.name}-\d{14}-[a-f0-9\-]{36}@#{server_info.domain}\>$/), "'#{message_id}' does not match expected pattern."
+      end
+
+      assert_equal 5, message_ids.uniq.size
+    end
   end
 end

--- a/test/as2_test.rb
+++ b/test/as2_test.rb
@@ -9,7 +9,7 @@ describe As2 do
       5.times do
         message_id = As2.generate_message_id(server_info)
         message_ids << message_id
-        assert message_id.match(/^\<#{server_info.name}-\d{14}-[a-f0-9\-]{36}@#{server_info.domain}\>$/), "'#{message_id}' does not match expected pattern."
+        assert message_id.match(/^\<#{server_info.name}-\d{8}-\d{6}-[a-f0-9\-]{36}@#{server_info.domain}\>$/), "'#{message_id}' does not match expected pattern."
       end
 
       assert_equal 5, message_ids.uniq.size

--- a/test/client/result_test.rb
+++ b/test/client/result_test.rb
@@ -16,25 +16,25 @@ describe As2::Client::Result do
 
   describe '#success' do
     it 'is true when everything looks good' do
-      subject = As2::Client::Result.new(@attributes)
+      subject = As2::Client::Result.new(**@attributes)
       assert subject.success
     end
 
     it 'is true on disposition processed/warning' do
       @attributes[:disposition] = 'automatic-action/MDN-sent-automatically; processed/Warning: authentication-failed, processing continued'
-      subject = As2::Client::Result.new(@attributes)
+      subject = As2::Client::Result.new(**@attributes)
       assert subject.success
     end
 
     it 'is false on disposition processed/error' do
       @attributes[:disposition] = 'automatic-action/MDN-sent-automatically; processed/error: authentication-failed'
-      subject = As2::Client::Result.new(@attributes)
+      subject = As2::Client::Result.new(**@attributes)
       assert !subject.success
     end
 
     it 'is false if there are signature verification issues' do
       @attributes[:signature_verification_error] = 'missing certificate'
-      subject = As2::Client::Result.new(@attributes)
+      subject = As2::Client::Result.new(**@attributes)
       assert !subject.success
     end
   end
@@ -42,13 +42,13 @@ describe As2::Client::Result do
   describe '#signature_verified' do
     it 'is true if signature_verification_error is nil' do
       @attributes[:signature_verification_error] = nil
-      subject = As2::Client::Result.new(@attributes)
+      subject = As2::Client::Result.new(**@attributes)
       assert subject.signature_verified
     end
 
     it 'is false if signature_verification_error is present' do
       @attributes[:signature_verification_error] = 'missing certificate'
-      subject = As2::Client::Result.new(@attributes)
+      subject = As2::Client::Result.new(**@attributes)
       assert !subject.signature_verified
     end
   end

--- a/test/client/result_test.rb
+++ b/test/client/result_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+
+describe As2::Client::Result do
+  before do
+    @attributes = {
+      disposition: 'automatic-action/MDN-sent-automatically; processed',
+      signature_verification_error: nil,
+      mic_matched: true,
+      mid_matched: true,
+      response: nil,
+      body: nil,
+      exception: nil,
+      outbound_message_id: nil
+    }
+  end
+
+  describe '#success' do
+    it 'is true when everything looks good' do
+      subject = As2::Client::Result.new(@attributes)
+      assert subject.success
+    end
+
+    it 'is true on disposition processed/warning' do
+      @attributes[:disposition] = 'automatic-action/MDN-sent-automatically; processed/Warning: authentication-failed, processing continued'
+      subject = As2::Client::Result.new(@attributes)
+      assert subject.success
+    end
+
+    it 'is false on disposition processed/error' do
+      @attributes[:disposition] = 'automatic-action/MDN-sent-automatically; processed/error: authentication-failed'
+      subject = As2::Client::Result.new(@attributes)
+      assert !subject.success
+    end
+
+    it 'is false if there are signature verification issues' do
+      @attributes[:signature_verification_error] = 'missing certificate'
+      subject = As2::Client::Result.new(@attributes)
+      assert !subject.success
+    end
+  end
+
+  describe '#signature_verified' do
+    it 'is true if signature_verification_error is nil' do
+      @attributes[:signature_verification_error] = nil
+      subject = As2::Client::Result.new(@attributes)
+      assert subject.signature_verified
+    end
+
+    it 'is false if signature_verification_error is present' do
+      @attributes[:signature_verification_error] = 'missing certificate'
+      subject = As2::Client::Result.new(@attributes)
+      assert !subject.signature_verified
+    end
+  end
+end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -98,8 +98,38 @@ describe As2::Client do
 
         result = @alice_client.send_file(file_name, content: File.read('test/fixtures/message.txt'))
 
+        assert_equal As2::Client::Result, result.class
+        assert result.success
+        assert result.mic_matched
+        assert result.mid_matched
         assert_equal file_name, file_name_received_by_bob
         assert_equal File.read('test/fixtures/message.txt'), file_content_received_by_bob
+      end
+    end
+
+    describe 'when file content has newlines' do
+      # we do some gsub string manipulation in a few places in As2::Client
+      # want to be sure this isn't affecting what is actually transmitted.
+      it 'sends content correctly' do
+        file_name_received_by_bob = nil
+        file_content_received_by_bob = nil
+
+        @bob_server = As2::Server.new(server_info: @bob_server_info, partner: @alice_partner) do |file_name, body|
+                        file_name_received_by_bob = file_name
+                        file_content_received_by_bob = body.to_s
+                      end
+
+        file_name = 'data.txt'
+
+        expected_content = "a\nb\tc\nd\r\ne\n"
+        result = @alice_client.send_file(file_name, content: expected_content)
+
+        assert_equal As2::Client::Result, result.class
+        assert result.success
+        assert result.mic_matched
+        assert result.mid_matched
+        assert_equal file_name, file_name_received_by_bob
+        assert_equal expected_content, file_content_received_by_bob
       end
     end
 
@@ -120,6 +150,10 @@ describe As2::Client do
         Dir.chdir(dir_name) do
           result = @alice_client.send_file(file_name)
 
+          assert_equal As2::Client::Result, result.class
+          assert result.success
+          assert result.mic_matched
+          assert result.mid_matched
           assert_equal file_name, file_name_received_by_bob
           assert_equal File.read(file_name), file_content_received_by_bob
         end
@@ -143,6 +177,10 @@ describe As2::Client do
 
         result = @alice_client.send_file(file_name, content: File.read('test/fixtures/multibyte.txt'))
 
+        assert_equal As2::Client::Result, result.class
+        assert result.success
+        assert result.mic_matched
+        assert result.mid_matched
         assert_equal file_name, file_name_received_by_bob
         assert_equal File.read('test/fixtures/multibyte.txt', encoding: 'ASCII-8BIT'), file_content_received_by_bob
       end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -56,7 +56,6 @@ describe As2::Client do
     assert_equal As2::Config.server_info, client.server_info
   end
 
-  # these are really 'dogfood' tests using both As2::Client and As2::Server.
   describe '#send_file' do
     before do
       # scenario: Alice is sending a message to Bob.
@@ -67,6 +66,8 @@ describe As2::Client do
       @bob_server_info = build_server_info('BOB', credentials: 'server')
 
       @alice_client = As2::Client.new(@bob_partner, server_info: @alice_server_info)
+      # individual tests will provide a different @bob_server if they want to assert on its behavior
+      @bob_server = As2::Server.new(server_info: @bob_server_info, partner: @alice_partner)
 
       stub_request(:post, @bob_partner.url).to_return do |request|
         # do all the HTTP things that rack would do during a real request
@@ -84,105 +85,130 @@ describe As2::Client do
       end
     end
 
-    describe 'when file_content is given' do
-      it 'sends the given file content' do
-        file_name_received_by_bob = nil
-        file_content_received_by_bob = nil
+    it 'captures and returns any exception raised while processing MDN response' do
+      expected_error_message = "error parsing attachment"
+      mail_replacment = ->(*args) { raise expected_error_message }
 
-        @bob_server = As2::Server.new(server_info: @bob_server_info, partner: @alice_partner) do |file_name, body|
-                        file_name_received_by_bob = file_name
-                        file_content_received_by_bob = body.to_s
-                      end
+      Mail.stub(:new, mail_replacment) do
+        result = @alice_client.send_file('file_name.txt', content: 'file content')
 
-        file_name = 'data.txt'
-
-        result = @alice_client.send_file(file_name, content: File.read('test/fixtures/message.txt'))
-
-        assert_equal As2::Client::Result, result.class
-        assert result.success
-        assert result.mic_matched
-        assert result.mid_matched
-        assert_equal file_name, file_name_received_by_bob
-        assert_equal File.read('test/fixtures/message.txt'), file_content_received_by_bob
+        assert_equal RuntimeError, result.exception.class
+        assert_equal expected_error_message, result.exception.message
+        assert_equal false, result.success
       end
     end
 
-    describe 'when file content has newlines' do
-      # we do some gsub string manipulation in a few places in As2::Client
-      # want to be sure this isn't affecting what is actually transmitted.
-      it 'sends content correctly' do
-        file_name_received_by_bob = nil
-        file_content_received_by_bob = nil
+    # these are really 'dogfood' tests using both As2::Client and As2::Server.
+    describe 'integration scenarios' do
+      # TODO: can we send/receive a 0-byte file w/o error?
 
-        @bob_server = As2::Server.new(server_info: @bob_server_info, partner: @alice_partner) do |file_name, body|
-                        file_name_received_by_bob = file_name
-                        file_content_received_by_bob = body.to_s
-                      end
+      describe 'when file_content is given' do
+        it 'sends the given file content' do
+          file_name_received_by_bob = nil
+          file_content_received_by_bob = nil
 
-        file_name = 'data.txt'
+          @bob_server = As2::Server.new(server_info: @bob_server_info, partner: @alice_partner) do |file_name, body|
+                          file_name_received_by_bob = file_name
+                          file_content_received_by_bob = body.to_s
+                        end
 
-        expected_content = "a\nb\tc\nd\r\ne\n"
-        result = @alice_client.send_file(file_name, content: expected_content)
+          file_name = 'data.txt'
 
-        assert_equal As2::Client::Result, result.class
-        assert result.success
-        assert result.mic_matched
-        assert result.mid_matched
-        assert_equal file_name, file_name_received_by_bob
-        assert_equal expected_content, file_content_received_by_bob
-      end
-    end
-
-    describe 'when file_content is nil' do
-      it 'reads content from file_name' do
-        file_name_received_by_bob = nil
-        file_content_received_by_bob = nil
-
-        @bob_server = As2::Server.new(server_info: @bob_server_info, partner: @alice_partner) do |file_name, body|
-                        file_name_received_by_bob = file_name
-                        file_content_received_by_bob = body.to_s
-                      end
-
-        file_path = 'test/fixtures/message.txt'
-        dir_name = File.dirname(file_path)
-        file_name = File.basename(file_path)
-
-        Dir.chdir(dir_name) do
-          result = @alice_client.send_file(file_name)
+          result = @alice_client.send_file(file_name, content: File.read('test/fixtures/message.txt'))
 
           assert_equal As2::Client::Result, result.class
           assert result.success
           assert result.mic_matched
           assert result.mid_matched
           assert_equal file_name, file_name_received_by_bob
-          assert_equal File.read(file_name), file_content_received_by_bob
+          assert_equal File.read('test/fixtures/message.txt'), file_content_received_by_bob
         end
       end
-    end
 
-    describe 'non-ASCII content' do
-      # not totally smooth due to character encoding. the bytes make it, but it's not a totally transparent process.
-      # lower-priority issue since EDI is all ASCII, but worth being aware of & fixing at some point.
-      # maybe Server could accept a parameter which tells us which character encoding to use?
-      it 'is not mangled too horribly' do
-        file_name_received_by_bob = nil
-        file_content_received_by_bob = nil
+      describe 'when file content has newlines' do
+        # we do some gsub string manipulation in a few places in As2::Client
+        # want to be sure this isn't affecting what is actually transmitted.
+        it 'sends content correctly' do
+          file_name_received_by_bob = nil
+          file_content_received_by_bob = nil
 
-        @bob_server = As2::Server.new(server_info: @bob_server_info, partner: @alice_partner) do |file_name, body|
-                        file_name_received_by_bob = file_name
-                        file_content_received_by_bob = body.to_s
-                      end
+          @bob_server = As2::Server.new(server_info: @bob_server_info, partner: @alice_partner) do |file_name, body|
+                          file_name_received_by_bob = file_name
+                          file_content_received_by_bob = body.to_s
+                        end
 
-        file_name = 'data.txt'
+          file_name = 'data.txt'
 
-        result = @alice_client.send_file(file_name, content: File.read('test/fixtures/multibyte.txt'))
+          expected_content = "a\nb\tc\nd\r\ne\n"
+          result = @alice_client.send_file(file_name, content: expected_content)
 
-        assert_equal As2::Client::Result, result.class
-        assert result.success
-        assert result.mic_matched
-        assert result.mid_matched
-        assert_equal file_name, file_name_received_by_bob
-        assert_equal File.read('test/fixtures/multibyte.txt', encoding: 'ASCII-8BIT'), file_content_received_by_bob
+          assert_equal As2::Client::Result, result.class
+          assert result.success
+          assert result.signature_verified
+          assert_nil result.signature_verification_error
+          assert result.mic_matched
+          assert result.mid_matched
+          assert_equal file_name, file_name_received_by_bob
+          assert_equal expected_content, file_content_received_by_bob
+        end
+      end
+
+      describe 'when file_content is nil' do
+        it 'reads content from file_name' do
+          file_name_received_by_bob = nil
+          file_content_received_by_bob = nil
+
+          @bob_server = As2::Server.new(server_info: @bob_server_info, partner: @alice_partner) do |file_name, body|
+                          file_name_received_by_bob = file_name
+                          file_content_received_by_bob = body.to_s
+                        end
+
+          file_path = 'test/fixtures/message.txt'
+          dir_name = File.dirname(file_path)
+          file_name = File.basename(file_path)
+
+          Dir.chdir(dir_name) do
+            result = @alice_client.send_file(file_name)
+
+            assert_equal As2::Client::Result, result.class
+            assert result.success
+            assert result.signature_verified
+            assert_nil result.signature_verification_error
+            assert result.mic_matched
+            assert result.mid_matched
+            assert_equal file_name, file_name_received_by_bob
+            assert_equal File.read(file_name), file_content_received_by_bob
+          end
+        end
+      end
+
+      describe 'non-ASCII content' do
+        # not totally smooth due to character encoding. the bytes make it, but it's not a totally transparent process.
+        # lower-priority issue since EDI is all ASCII, but worth being aware of & fixing at some point.
+        # maybe Server could accept a parameter which tells us which character encoding to use?
+        it 'is not mangled too horribly' do
+          file_name_received_by_bob = nil
+          file_content_received_by_bob = nil
+
+          @bob_server = As2::Server.new(server_info: @bob_server_info, partner: @alice_partner) do |file_name, body|
+                          file_name_received_by_bob = file_name
+                          file_content_received_by_bob = body.to_s
+                        end
+
+          file_name = 'data.txt'
+
+          result = @alice_client.send_file(file_name, content: File.read('test/fixtures/multibyte.txt'))
+
+          assert_equal As2::Client::Result, result.class
+
+          assert result.success
+          assert result.signature_verified
+          assert_nil result.signature_verification_error
+          assert result.mic_matched
+          assert result.mid_matched
+          assert_equal file_name, file_name_received_by_bob
+          assert_equal File.read('test/fixtures/multibyte.txt', encoding: 'ASCII-8BIT'), file_content_received_by_bob
+        end
       end
     end
   end

--- a/test/digest_selector_test.rb
+++ b/test/digest_selector_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+describe As2::DigestSelector do
+  describe '.for_code' do
+    it 'can build a base64digest for all supported algorithm codes' do
+      As2::DigestSelector.valid_codes.each do |code|
+        assert As2::DigestSelector.for_code(code).base64digest("message body")
+      end
+    end
+
+    # not sure if this is better or if we should raise.
+    # current thinking is: "MDN verification failure" > "raising an exception"
+    it 'defaults to SHA1 if code is unrecognized' do
+      assert_equal OpenSSL::Digest::SHA1, As2::DigestSelector.for_code('blat')
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require 'as2'
 require 'pry'
 
 require 'minitest/autorun'
+require 'minitest/focus'
 require 'webmock/minitest'
 
 WebMock.disable_net_connect!


### PR DESCRIPTION

  * rename several variables to clarify their purpose.
  * perform MIC calculation using same algorithm as the server. server may
    calculate MIC using a different algorithm than the one we specify, so we
    can't calculate our MIC until we get the server's response.
  * update MDN signature verification to ensure the MDN was signed by the
    expected partner, using same set of options as in As2::Message. see
    comments & notes in 8788676078bd367c56b4cdf432b479fa4f6e6e2f.
  * in payload, use `\r\n` as line terminator. server will do this same
    canonicalization prior to calculating MIC, so we need to do the same in
    order for MICs to match.

> For any signed messages, the MIC to be returned is calculated on the
> RFC1767 /RFC3023 MIME header and content. Canonicalization on the MIME headers
> MUST be performed before the MIC is calculated, since the sender requesting
> the signed receipt was also REQUIRED to canonicalize.

https://datatracker.ietf.org/doc/html/rfc4130#section-7.3.1

"Canonicalization" isn't defined in RFC4130, but I think it just means that all
lines are terminated with "\r\n".

> Messages are divided into lines of characters. A line is a series of characters
> that is delimited with the two characters carriage-return and line-feed; that
> is, the carriage return (CR) character (ASCII value 13) followed immediately
> by the line feed (LF) character (ASCII value 10).

https://datatracker.ietf.org/doc/html/rfc2822