### PR TITLE
default to AES256 cipher & SHA256 hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ along.
      4. Use of Synchronous or Asynchronous Receipts: We do not support asynchronous
        delivery of MDNs.
      5. Security Formatting: We should be reasonably compliant here.
-     6. Hash Function, Message Digest Choices: We currently always use sha1. If a
-       partner asks for a different algorithm, we'll always use sha1 and partner
+     6. Hash Function, Message Digest Choices: We currently always use sha256. If a
+       partner asks for a different algorithm, we'll always use sha256 and partner
        will see a MIC verification failure. AS2 RFC specifically prefers sha1 and
        mentions md5. Mendelson AS2 server supports a number of other algorithms.
        (sha256, sha512, etc)

--- a/lib/as2/message.rb
+++ b/lib/as2/message.rb
@@ -80,8 +80,12 @@ module As2
     end
 
     def mic
-      # TODO: could use As2::DigestSelector if a different algo is needed.
-      OpenSSL::Digest::SHA1.base64digest(attachment.raw_source.strip)
+      digest = As2::DigestSelector.for_code(mic_algorithm)
+      digest.base64digest(attachment.raw_source.strip)
+    end
+
+    def mic_algorithm
+      'sha256'
     end
 
     # Return the attached file, use .filename and .body on the return value

--- a/lib/as2/server.rb
+++ b/lib/as2/server.rb
@@ -55,10 +55,11 @@ module As2
         end
       end
 
-      send_mdn(env, message.mic)
+      send_mdn(env, message.mic, message.mic_algorithm)
     end
 
-    def send_mdn(env, mic, failed = nil)
+    def send_mdn(env, mic, mic_algorithm, failed = nil)
+      # rules for MDN construction are covered in https://datatracker.ietf.org/doc/html/rfc4130#section-7.4.2
       report = MimeGenerator::Part.new
       report['Content-Type'] = 'multipart/report; report-type=disposition-notification'
 
@@ -85,7 +86,7 @@ module As2
       else
         options['Disposition'] = 'automatic-action/MDN-sent-automatically; processed'
       end
-      options['Received-Content-MIC'] = "#{mic}, sha1" if mic
+      options['Received-Content-MIC'] = "#{mic}, #{mic_algorithm}" if mic
       notification.body = options.map{|n, v| "#{n}: #{v}"}.join("\r\n")
       report.add_part notification
 
@@ -120,7 +121,7 @@ module As2
 
     def send_error(env, msg)
       logger(env).error msg
-      send_mdn env, nil, msg
+      send_mdn env, nil, 'sha1', msg
     end
   end
 end

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -58,7 +58,13 @@ describe As2::Message do
 
   describe '#mic' do
     it 'returns a message integrity check value' do
-      assert_equal @message.mic, "nyyjxao566rCbElBu0v+lrDjAq4="
+      assert_equal @message.mic, "7S8fpWpx+ASDj0sCAIfS64Q+sm0ezIpDLhPs9wIEy8I="
+    end
+  end
+
+  describe '#mic_algorithm' do
+    it 'returns a string describing the algorithm used for MIC calculation' do
+      assert_equal @message.mic_algorithm, 'sha256'
     end
   end
 


### PR DESCRIPTION
previously, we'd be using:

  * whichever cipher was default for our version of ruby. (was RC2 in my case.)
  * sha1 for MIC calculations

we may need to make this a configuration option at some point.