### PR TITLE
handle unsigned MDN responses

### DIFF
--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -56,6 +56,69 @@ describe As2::Client do
     assert_equal As2::Config.server_info, client.server_info
   end
 
+  describe '#evaluate_mdn' do
+    before do
+      partner = build_partner('CLIENT', credentials: 'client')
+      server_info = build_server_info('SERVER', credentials: 'server')
+      @client = As2::Client.new(partner, server_info: server_info)
+
+      # capture this out-of-band when i wrote the test.
+      @document_payload =  "Content-Type: text/plain\r\n"
+      @document_payload << "Content-Transfer-Encoding: base64\r\n"
+      @document_payload << "Content-Disposition: attachment; filename=test.txt\r\n"
+      @document_payload << "\r\n"
+      @document_payload << Base64.strict_encode64('This is a test message.')
+    end
+
+    it 'handles a signed mdn' do
+      mdn_data = YAML.load(File.read('test/fixtures/signed_mdn.yml'))
+
+      result = @client.evaluate_mdn(
+                 mdn_body: mdn_data['body'],
+                 mdn_content_type: mdn_data['headers']['Content-Type'],
+                 original_message_id: '<SERVER-20220318-222842-b176dc1a-44fd-4f9c-ac61-813fbb0f579a@server.test-ruby-as2.com>',
+                 original_body: @document_payload
+               )
+
+      assert result[:mic_matched]
+      assert result[:mid_matched]
+      assert_nil result[:signature_verification_error]
+      assert_equal 'automatic-action/MDN-sent-automatically; processed', result[:disposition]
+
+      expected_body = "The AS2 message has been received. " \
+        "Thank you for exchanging AS2 messages with mendelson opensource AS2.\n" \
+        "Please download your free copy of mendelson opensource AS2 today at http://opensource.mendelson-e-c.com"
+
+      assert_equal expected_body, result[:plain_text_body]
+    end
+
+    it 'handles an unsigned mdn' do
+      mdn_data = YAML.load(File.read('test/fixtures/unsigned_mdn.yml'))
+
+      result = @client.evaluate_mdn(
+                 mdn_body: mdn_data['body'],
+                 mdn_content_type: mdn_data['headers']['Content-Type'],
+                 original_message_id: '<SERVER-20220318-222924-774c8348-6372-4f7e-b84f-d7fced6daf58@server.test-ruby-as2.com>',
+                 original_body: @document_payload
+               )
+
+      assert_nil result[:mic_matched]
+      assert result[:mid_matched]
+      assert_equal :not_checked, result[:signature_verification_error]
+      assert_equal 'automatic-action/MDN-sent-automatically; processed/error: unknown-trading-partner', result[:disposition]
+
+      expected_body = "Thank you for exchanging AS2 messages with mendelson opensource AS2.\n" \
+        "Please download your free copy of mendelson opensource AS2 + today at http://opensource.mendelson-e-c.com.\n\n" \
+        "An error occured during the AS2 message processing: Sender AS2 id SERVER is unknown."
+
+      assert_equal expected_body, result[:plain_text_body]
+    end
+
+    it "parses an MDN with a lower-case 'disposition:' header" # eg: "disposition: automatic-action/MDN-sent-automatically; processed"
+    it "parses an MDN with extended 'Content-Type:'" # eg: 'Content-Type: text/plain; charset="UTF-8"'
+    it "parses an MDN which is missing 'Received-Content-MIC:'"
+  end
+
   describe '#send_file' do
     before do
       # scenario: Alice is sending a message to Bob.
@@ -96,10 +159,6 @@ describe As2::Client do
         assert_nil result.success
       end
     end
-
-    it "parses an MDN with a 'disposition:' header" # eg: "disposition: automatic-action/MDN-sent-automatically; processed"
-    it "parses an MDN with extended 'Content-Type:'" # eg: 'Content-Type: text/plain; charset="UTF-8"'
-    it "parses an MDN which is missing 'Received-Content-MIC:'"
 
     # these are really 'dogfood' tests using both As2::Client and As2::Server.
     describe 'integration scenarios' do

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -93,7 +93,7 @@ describe As2::Client do
 
         assert_equal RuntimeError, result.exception.class
         assert_equal expected_error_message, result.exception.message
-        assert_equal false, result.success
+        assert_nil result.success
       end
     end
 

--- a/test/fixtures/signed_mdn.yml
+++ b/test/fixtures/signed_mdn.yml
@@ -1,0 +1,29 @@
+---
+code: '200'
+headers:
+  Date: Fri, 18 Mar 2022 17:28:42 CDT
+  Mime-Version: '1.0'
+  Server: mendelson opensource AS2 1.1 build 59 - www.mendelson-e-c.com
+  As2-Version: '1.2'
+  Message-Id: "<mendelson_opensource_AS2-1647642522866-36@CLIENT_SERVER>"
+  Content-Type: "multipart/signed; protocol=\"application/pkcs7-signature\"; micalg=sha256;
+    \tboundary=\"----=_Part_129_1965967973.1647642522891\""
+  As2-To: SERVER
+  Ediint-Features: multiple-attachments, CEM
+  As2-From: CLIENT
+  Content-Length: '3383'
+  Connection: close
+body: "Date: Fri, 18 Mar 2022 17:28:42 -0500 (CDT)\r\n\r\n------=_Part_129_1965967973.1647642522891\r\nDate:
+  Fri, 18 Mar 2022 17:28:42 -0500 (CDT)\r\nContent-Type: multipart/report; report-type=disposition-notification;
+  \r\n\tboundary=\"----=_Part_126_1516173185.1647642522890\"\r\n\r\n------=_Part_126_1516173185.1647642522890\r\nContent-Type:
+  text/plain\r\nContent-Transfer-Encoding: 7bit\r\n\r\nThe AS2 message has been received.
+  Thank you for exchanging AS2 messages with mendelson opensource AS2.\r\nPlease download
+  your free copy of mendelson opensource AS2 today at http://opensource.mendelson-e-c.com\r\n\r\n\r\n------=_Part_126_1516173185.1647642522890\r\nContent-Type:
+  message/disposition-notification\r\nContent-Transfer-Encoding: 7bit\r\n\r\nReporting-UA:
+  mendelson opensource AS2\r\nOriginal-Recipient: rfc822; CLIENT\r\nFinal-Recipient:
+  rfc822; CLIENT\r\nOriginal-Message-ID: <SERVER-20220318-222842-b176dc1a-44fd-4f9c-ac61-813fbb0f579a@server.test-ruby-as2.com>\r\nDisposition:
+  automatic-action/MDN-sent-automatically; processed\r\nReceived-Content-MIC: oH0vz8s6oS7SoqF01XHsASudN05EPgouF1IFMSNsv30=,
+  sha-256\r\n\r\n------=_Part_126_1516173185.1647642522890--\r\n\r\n------=_Part_129_1965967973.1647642522891\r\nContent-Type:
+  application/pkcs7-signature; name=smime.p7s; smime-type=signed-data\r\nContent-Transfer-Encoding:
+  base64\r\nContent-Disposition: attachment; filename=\"smime.p7s\"\r\nContent-Description:
+  S/MIME Cryptographic Signature\r\n\r\nMIAGCSqGSIb3DQEHAqCAMIACAQExDzANBglghkgBZQMEAgEFADCABgkqhkiG9w0BBwEAAKCAMIID\r\nADCCAegCCQCRBvgFyC5j1jANBgkqhkiG9w0BAQsFADBCMR0wGwYDVQQKDBRSdWJ5IEFTMiBUZXN0\r\nIENsaWVudDEhMB8GA1UEAwwYY2xpZW50LnRlc3QtcnVieS1hczIuY29tMB4XDTIxMTIxMzE1Mjcz\r\nOVoXDTI2MTIxMjE1MjczOVowQjEdMBsGA1UECgwUUnVieSBBUzIgVGVzdCBDbGllbnQxITAfBgNV\r\nBAMMGGNsaWVudC50ZXN0LXJ1YnktYXMyLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC\r\nggEBALl1kg7W3ydXm69reDDhArcTcn2IBuHHQztYGVKmn7vGyabgkKPB+rOcOTpuRwFlWM5z4nzq\r\nmHhTImplCYuAa4kml+EhxrbZ8wmg09Qi2shEQ1Ppx6gXXAVQSQ/bu/ybpCprRpmFLfpWG5aPmCFN\r\nCsbKthOYxWLQL3132TGgXDyfguhHIQf/XcXIKhBRsUC4hiPlwYaPbrBQ0F8yv4HCNXUXIrePdhZD\r\nt5yoRB7O61rYo9OpVg6jEuoVcRjJxRpBOe+Fqyux5dGeWkOSytkRjXxwKHx5MsphCwRlsFZlUhuv\r\n+5Nwz7Cr6BdE8+cfkW+23nyKzMznGlG3tChuJcGRBpECAwEAATANBgkqhkiG9w0BAQsFAAOCAQEA\r\nKzYNcuBSrzhSMSovvz/oLtoVYuHTPZ41P7XfC1os0AngPXOSmXex1FZWQ2LYnNSZxwP6pmy0ukyz\r\n404oNgleiBp/hu0lzkOOZgExHa/txXhTy3G6ZKCKHIWaXFbS4LRxzN+ZbmUnFIlqBSpbykhlvvn6\r\nrtswCwhVP8mxo1KpJCFYBPjliPlEMDOZw+p/dwMkrgzckhYn2YD+F6B0wFoToJjkvvEj7hC6gtE/\r\nu093OEEJ4PMadFM9XC0ofTVYUonzAz22Z3bCQxg0S5S5YML7qdhZGX0TvNybFD8b1mZQkvhajpMg\r\niw3c9Qp7Je6yX+9Z+x+JpZM1YMOmqB0ZVmE19QAAMYICSzCCAkcCAQEwTzBCMR0wGwYDVQQKDBRS\r\ndWJ5IEFTMiBUZXN0IENsaWVudDEhMB8GA1UEAwwYY2xpZW50LnRlc3QtcnVieS1hczIuY29tAgkA\r\nkQb4BcguY9YwDQYJYIZIAWUDBAIBBQCggc4wGAYJKoZIhvcNAQkDMQsGCSqGSIb3DQEHATAcBgkq\r\nhkiG9w0BCQUxDxcNMjIwMzE4MjIyODQyWjAtBgkqhkiG9w0BCTQxIDAeMA0GCWCGSAFlAwQCAQUA\r\noQ0GCSqGSIb3DQEBCwUAMC8GCSqGSIb3DQEJBDEiBCBICIQF3HZv8k+CuTwkKwfZi80pyZ5B4pqs\r\nKldXsxKGCDA0BgkqhkiG9w0BCQ8xJzAlMAoGCCqGSIb3DQMHMA4GCCqGSIb3DQMCAgIAgDAHBgUr\r\nDgMCBzANBgkqhkiG9w0BAQsFAASCAQCAE0HotflYmbnPm/54oyw65lp6w8sC2O7s48AvCzO6L7i0\r\nw4asXdprRxUZtyEJRBL9OpjKhMTnp9Ua54kEcuNwTZddXygCT1X7W4nceS8JXoJvVBIkzVuwv5/O\r\nzx5YjcwrxilsVCQF3FVjTQc9MQCG+LyL3ZYJ7iFXNnfEu8iskfPaoAf3ngFTrxFobn3XRpNLtMQG\r\nwqb1dGIfZU3oGyRJUCFsth63sgaaMnEBa77ORODD3sLcZ3HYdiFu80vJxyWUUaMnbZsnIwsCQb1K\r\nhjuYc9ze0YjrIye/yGAkCmu3adL1YKeuNUKfN4+sZSr0j5s0UV0N/m0sgfF7cAagu4B3AAAAAAAA\r\n\r\n------=_Part_129_1965967973.1647642522891--\r\n"

--- a/test/fixtures/unsigned_mdn.yml
+++ b/test/fixtures/unsigned_mdn.yml
@@ -1,0 +1,23 @@
+---
+code: '200'
+headers:
+  Date: Fri, 18 Mar 2022 17:29:24 CDT
+  Mime-Version: '1.0'
+  Server: mendelson opensource AS2 1.1 build 59 - www.mendelson-e-c.com
+  As2-Version: '1.2'
+  Message-Id: "<mendelson_opensource_AS2-1647642564796-37@CLIENT_SERVER>"
+  Content-Type: "multipart/report; report-type=disposition-notification; \tboundary=\"----=_Part_131_1228550367.1647642564796\""
+  As2-To: SERVER
+  Ediint-Features: multiple-attachments, CEM
+  As2-From: CLIENT
+  Content-Length: '904'
+  Connection: close
+body: "Date: Fri, 18 Mar 2022 17:29:24 -0500 (CDT)\r\n\r\n------=_Part_131_1228550367.1647642564796\r\nContent-Type:
+  text/plain\r\nContent-Transfer-Encoding: 7bit\r\n\r\nThank you for exchanging AS2
+  messages with mendelson opensource AS2.\r\nPlease download your free copy of mendelson
+  opensource AS2 + today at http://opensource.mendelson-e-c.com.\r\n\r\nAn error occured
+  during the AS2 message processing: Sender AS2 id SERVER is unknown.\r\n------=_Part_131_1228550367.1647642564796\r\nContent-Type:
+  message/disposition-notification\r\nContent-Transfer-Encoding: 7bit\r\n\r\nReporting-UA:
+  mendelson opensource AS2\r\nOriginal-Recipient: rfc822; CLIENT\r\nFinal-Recipient:
+  rfc822; CLIENT\r\nOriginal-Message-ID: <SERVER-20220318-222924-774c8348-6372-4f7e-b84f-d7fced6daf58@server.test-ruby-as2.com>\r\nDisposition:
+  automatic-action/MDN-sent-automatically; processed/error: unknown-trading-partner\r\n\r\n------=_Part_131_1228550367.1647642564796--\r\n"


### PR DESCRIPTION
if we send an invalid As2-From, the MDN response will be unsigned. (because partner won't know which certificate to use to sign it with.)

this change should improve our odds of successfully parsing the MDN.